### PR TITLE
Fix for Q module not found when running on Linux based systems

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var R = require('ramda');
 var validator = require('validator');
-var Q = require('Q');
+var Q = require('q');
 
 var pickMethods = R.pipe(R.keys, R.filter(R.test(/^is/)));
 


### PR DESCRIPTION
Q module should be included in lowercase.
This is causing a crash when used in builds/tests on Travis CI Linux.
